### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,6 +25,7 @@ Download using the [GitHub `.zip` download](https://github.com/dracula/terminal-
 
 1.  _Terminal > Settings Tab_;
 2.  Click _"Gear" icon_;
-3.  Click _Import..._;
-4.  Select the `Dracula.terminal` file;
-5.  Click _Default_. 💜
+3.  On the left hand side under the list of themes, click "..." button;
+4.  Click _Import..._;
+5.  Select the `Dracula.terminal` file;
+6.  Click _Default_. 💜


### PR DESCRIPTION
The "Import" button has moved to the "Profiles" tab and this commit resolves the confusion of activating the theme by adding one step to the process.

No "Import" button in "General" tab:
<img width="779" alt="Screenshot 2023-09-13 at 10 53 10 PM" src="https://github.com/dracula/terminal-app/assets/7308807/bcde1ada-b6c8-43ff-8dbe-610484e51d4c">

"Import" button in the "Profiles" tab:
<img width="688" alt="Screenshot 2023-09-13 at 10 53 55 PM" src="https://github.com/dracula/terminal-app/assets/7308807/f11c3de8-20c8-4109-a426-c422f332925e">
