### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,8 +23,9 @@ Download using the [GitHub `.zip` download](https://github.com/dracula/terminal-
 
 #### Activating theme
 
-1.  _Terminal > Settings Tab_;
-2.  Click _"Gear" icon_;
-3.  Click _Import..._;
-4.  Select the `Dracula.terminal` file;
-5.  Click _Default_. 💜
+1.  _Terminal > Settings_;
+2.  Click _"Profiles" tab_;
+3.  On the left hand side under the list of themes, click "..." button;
+4.  Click _Import..._;
+5.  Select the `Dracula.terminal` file;
+6.  Click _Default_. 💜


### PR DESCRIPTION
The "Import" button has moved to the "Profiles" tab and this commit resolves the confusion of activating the theme by adding one step to the process.

No "Import" button on the "General" tab:
<img width="779" alt="Screenshot 2023-09-13 at 10 53 10 PM" src="https://github.com/dracula/terminal-app/assets/7308807/adf15e87-b7b1-4bf2-9f9e-ead92c2cd726">

"Import" button on the "Profiles" tab:
<img width="688" alt="Screenshot 2023-09-13 at 10 53 55 PM" src="https://github.com/dracula/terminal-app/assets/7308807/2de5ae00-8045-4e13-8bb3-07ce90bc3990">
